### PR TITLE
Seed

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_094132) do
+ActiveRecord::Schema.define(version: 2020_09_26_082406) do
 
   create_table "addresses", force: :cascade do |t|
     t.integer "customer_id"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_094132) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
-    t.boolean "is_valid"
+    t.boolean "is_valid", default: false
     t.index ["email"], name: "index_customers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,7 +58,6 @@ ActiveRecord::Schema.define(version: 2020_09_26_082406) do
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
     t.boolean "is_valid", default: false
-
     t.index ["deleted_at"], name: "index_customers_on_deleted_at"
     t.index ["email"], name: "index_customers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,15 +28,7 @@
 
 end
 
-9.times do |n|
-  Address.create!(
-    name: "田中　太郎#{n + 1}",
-    postal_code: "123456#{n + 1}",
-    address: "東京都港区台場1-11-#{n + 1}",
-    customer_id: n + 1
-  )
 
-end
 
 
 


### PR DESCRIPTION
seed内配送先初期値を削除し、新規会員が配送先一覧を表示した際に初期設定の配送先を表示しないようにしました。